### PR TITLE
Unignore wiimote and spacenav_node for Foxy

### DIFF
--- a/foxy.ignored
+++ b/foxy.ignored
@@ -1,4 +1,2 @@
 joystick_drivers
 ps3joy
-spacenav_node
-wiimote


### PR DESCRIPTION
They are available in the latest release.